### PR TITLE
test2090: don't fail when OpenSSL is build with sslkeylog support

### DIFF
--- a/tests/data/test2090
+++ b/tests/data/test2090
@@ -53,6 +53,7 @@ Accept: */*
 CLIENT_RANDOM %repeat[32 x 9A]% %repeat[48 x BC]%
 </file>
 <stripfile>
+$_ = '' if /^CLIENT_RANDOM / && $seen_cr++
 s/^CLIENT_RANDOM [0-9a-fA-F]{64} [0-9a-fA-F]{96}/CLIENT_RANDOM %repeat[32 x 9A]% %repeat[48 x BC]%/g
 </stripfile>
 </verify>


### PR DESCRIPTION
When OpenSSL is build with sslkeylog support, then OpenSSL itself writes `CLIENT_RANDOM` lines to the key log file. This causes the test to fail.

```
setenv SSLKEYLOGFILE = log/2090.log.ssl
test 2090...[HTTPS request with SSLKEYLOGFILE set]
../libtool --mode=execute /usr/bin/valgrind --tool=memcheck --quiet --leak-check=yes --suppressions=../../tests/valgrind.supp --num-callers=16 --log-file=log/valgrind2090 ../src/curl -q --output log/curl2090.out  --include --trace-ascii log/trace2090 --trace-time --cacert ./certs/test-ca.crt --tls-max 1.2 https://localhost:33191/2090 > log/stdout2090 2> log/stderr2090
CMD (0): ../libtool --mode=execute /usr/bin/valgrind --tool=memcheck --quiet --leak-check=yes --suppressions=../../tests/valgrind.supp --num-callers=16 --log-file=log/valgrind2090 ../src/curl -q --output log/curl2090.out  --include --trace-ascii log/trace2090 --trace-time --cacert ./certs/test-ca.crt --tls-max 1.2 https://localhost:33191/2090 > log/stdout2090 2> log/stderr2090
 2090: output (log/2090.log.ssl) FAILED:
--- log/check-expected  2026-02-13 12:21:45.055948465 +0000
+++ log/check-generated 2026-02-13 12:21:45.055927983 +0000
@@ -1 +1,2 @@
 CLIENT_RANDOM 9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A BCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBC[CR][LF]
+CLIENT_RANDOM 9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A BCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBC[CR][LF]
== Contents of files in the log/ directory after test 2090
=== Start of file 2090.log.ssl
 CLIENT_RANDOM ef38659be2d07fc69144dec78770565bfd136e0737cc3488d74c8894d7be3f48 788921ea581f012f8fc0e70047c028687d5189030b97eae5c5dddcf6080a168b6dfed5c42fee0b0065103ee6ad2d9f61
 CLIENT_RANDOM ef38659be2d07fc69144dec78770565bfd136e0737cc3488d74c8894d7be3f48 788921ea581f012f8fc0e70047c028687d5189030b97eae5c5dddcf6080a168b6dfed5c42fee0b0065103ee6ad2d9f61
=== End of file 2090.log.ssl
=== Start of file check-expected
 CLIENT_RANDOM 9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A BCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBC[CR][LF]
=== End of file check-expected
=== Start of file check-generated
 CLIENT_RANDOM 9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A BCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBC[CR][LF]
 CLIENT_RANDOM 9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A9A BCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBCBC[CR][LF]
=== End of file check-generated
=== Start of file commands.log
 ../libtool --mode=execute /usr/bin/valgrind --tool=memcheck --quiet --leak-check=yes --suppressions=../../tests/valgrind.supp --num-callers=16 --log-file=log/valgrind2090 ../src/curl -q --output log/curl2090.out  --include --trace-ascii log/trace2090 --trace-time --cacert ./certs/test-ca.crt --tls-max 1.2 https://localhost:33191/2090 > log/stdout2090 2> log/stderr2090
=== End of file commands.log
=== Start of file curl2090.out
%< ---------------
```

Let's remove the duplicate `CLIENT_RANDOM` lines from the test.